### PR TITLE
[SPECIAL-7825] Библиотеки не поддерживают SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ import { hover } from '@ktsstudio/mediaproject-style/mixins';
 Для корректной работы библиотеки с Next.js необходимо:
 1) установить пакет [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules)
 2) подключить плагин в next.config.js
+
 ```
+// next.config.js
+
 const withTM = require('next-transpile-modules')(['@ktsstudio/mediaproject-style'], {
   resolveSymlinks: true,
 });
@@ -62,6 +65,7 @@ module.exports = (_phase, { defaultConfig }) => {
 ```
 
 3) При ssr использовать функции которые не содержат обращения к window.
+
 Пример:
 ```
 import { hover, square } from '@ktsstudio/mediaproject-style/mixins';

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 `npm install @ktsstudio/mediaproject-style`
 
 `yarn add @ktsstudio/mediaproject-style`
-
 ### Методы
 
 * [markup](./src/markup.ts) - утилита для адаптивной верстки на rem
@@ -27,12 +26,55 @@
 
 ```typescript
 import { mixins } from '@ktsstudio/mediaproject-style';
+или
+import { hover } from '@ktsstudio/mediaproject-style/mixins';
 ```
 
 Чтобы использовать миксин, анимацию или утилиту в проекте с Sass, импортируйте файл с ними:
 
 ```scss
 @import '~@ktsstudio/mediaproject-style/dist/mixins';
+```
+
+### Использование с Next.js
+Для корректной работы библиотеки с Next.js необходимо:
+1) установить пакет [next-transpile-modules](https://www.npmjs.com/package/next-transpile-modules)
+2) подключить плагин в next.config.js
+```
+const withTM = require('next-transpile-modules')(['@ktsstudio/mediaproject-style'], {
+  resolveSymlinks: true,
+});
+
+const plugins = [
+  withTM,
+];
+
+const nextConfig = {
+  ...
+  compiler: {
+    styledComponents: true,
+  }
+}
+
+module.exports = (_phase, { defaultConfig }) => {
+  return plugins.reduce((acc, plugin) => plugin(acc), { ...defaultConfig, ...nextConfig })
+}
+```
+
+3) При ssr использовать функции которые не содержат обращения к window.
+Пример:
+```
+import { hover, square } from '@ktsstudio/mediaproject-style/mixins';
+import { appearAnimation } from '@ktsstudio/mediaproject-style/animations';
+```
+
+3.1) В случае если функция нужна только на клиенте, можно подгрузить библиотеку асинхронно либо воспользоваться [next/dynamic](https://nextjs.org/docs/advanced-features/dynamic-import)
+```
+ React.useEffect(() => {
+    import('@ktsstudio/mediaproject-style/markup').then((module) => {
+      ...
+    })
+  }, []);
 ```
 
 ### Обратная связь

--- a/package.json
+++ b/package.json
@@ -1,12 +1,26 @@
 {
   "name": "@ktsstudio/mediaproject-style",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "KTS Studio",
   "license": "MIT",
   "description": "Package with common styles for media projects",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
+  "exports": {
+    "./mixins": "./dist/mixins.js",
+    "./animations": "./dist/animations.js",
+    "./markup": "./dist/markup.js",
+    "./utils": "./dist/utils.js"
+  },
+  "typesVersions": {
+    "*": {
+      "mixins": ["dist/types/mixins.d.ts"],
+      "animations": ["dist/types/animations.d.ts"],
+      "markup": ["dist/types/markup.d.ts"],
+      "utils": ["dist/types/utils.d.ts"]
+    }
+  },
   "scripts": {
     "rm-build": "rimraf dist",
     "lint": "eslint src --fix",
@@ -14,7 +28,7 @@
     "tsc-check": "tsc --skipLibCheck --noEmit --project tsconfig.json",
     "build-ts": "tsc --module es6 --target es6 --outDir dist --declarationDir dist/types",
     "build-styles": "cpx src/**/*.*css dist",
-    "build": "yarn run rm-build; yarn run build-ts; yarn run build-styles",
+    "build": "yarn run rm-build && yarn run build-ts && yarn run build-styles",
     "precommit": "lint-staged"
   },
   "lint-staged": {


### PR DESCRIPTION
При импорте всей либы
```
import { mixins } from '@ktsstudio/mediaproject-style';
```
импортируются функции в которых есть использование window, это ломает SSR.

Можно импортировать только нужные функции
```
@import '~@ktsstudio/mediaproject-style/dist/mixins';
```

т.к либа не траспилируется, я добавил инструкцию в README о том как можно завести либу на next.js
